### PR TITLE
fix: replaces octokit parameter for setting repo privacy

### DIFF
--- a/src/services/create-site/github-publisher.ts
+++ b/src/services/create-site/github-publisher.ts
@@ -20,7 +20,7 @@ export default ({
       org: 'isomerpages',
       name: repoName,
       description: `Staging: https://${repoName}-staging.netlify.app | Production: https://${repoName}-prod.netlify.app`,
-      visibility: 'public',
+      private: false,
     }),
     octokit.teams.create({
       org: 'isomerpages',


### PR DESCRIPTION
## Bug

When creating a Github repo via `site-creation-backend`, we receive an error on the backend with the message:
```
The visibility parameter is valid only when the nebula-preview header is provided.
```

 Based on our investigation, when using the GitHub API to create a repository with parameter `visibility: public`, a header `application/vnd.github.nebula-preview+json` must be set to access the `visibility` value. This is documented [here](https://developer.github.com/changes/2019-12-03-internal-visibility-changes/). 

## Fix

In the call to create the site repo, we replace the `visibility: public` parameter with `private: false`, documented [here](https://docs.github.com/en/rest/reference/repos#create-an-organization-repository), which does not require the `application/vnd.github.nebula-preview+json` header to be set. 