### PR TITLE
fix: create default base isomer repo

### DIFF
--- a/src/controllers/create-site.ts
+++ b/src/controllers/create-site.ts
@@ -4,7 +4,9 @@ import winston from 'winston'
 import { DecryptedContent } from '@opengovsg/formsg-sdk/dist/types'
 
 import makeSiteSpecification from '../services/create-site/formsg-site-spec'
-import generateSite from '../services/create-site/site-generator'
+import generateSite, {
+  SiteSpecification,
+} from '../services/create-site/site-generator'
 
 const onSuccess = (repoName: string) => (supportEmail: string) => `
 The Isomer site for ${repoName} has been created successfully! 
@@ -21,6 +23,18 @@ The Isomer guide is available at https://v2.isomer.gov.sg.
 `
 
 const action = 'creating'
+
+// Base pages and folders to create
+const SAMPLE_PAGES = ['example-page']
+const SAMPLE_COLLECTION = {
+  'example-collection': {
+    'example-page': [],
+  },
+}
+const SAMPLE_RESOURCES = {
+  name: 'resources',
+  categories: ['example-category'],
+}
 
 export default (options: {
   publishToGitHub: (repoName: string) => Promise<number>
@@ -45,8 +59,7 @@ export default (options: {
   let statusCode = 201
 
   const { responses } = res.locals.submission as DecryptedContent
-  const siteSpecification = makeSiteSpecification({ responses })
-  const { repoName } = siteSpecification
+  const repoName = makeSiteSpecification({ responses })
 
   let to = ''
 
@@ -55,6 +68,13 @@ export default (options: {
   )
   if (requestorEmailResponse && requestorEmailResponse.answer) {
     to = requestorEmailResponse.answer
+  }
+
+  const siteSpecification: SiteSpecification = {
+    repoName: repoName,
+    pages: SAMPLE_PAGES,
+    collections: SAMPLE_COLLECTION,
+    resourceRoom: SAMPLE_RESOURCES,
   }
 
   try {

--- a/src/services/create-site/formsg-site-spec.ts
+++ b/src/services/create-site/formsg-site-spec.ts
@@ -1,74 +1,12 @@
-import { SiteSpecification } from './site-generator'
-
 import { FormField } from '@opengovsg/formsg-sdk/dist/types'
 
-export default function ({
-  responses,
-}: {
-  responses: FormField[]
-}): SiteSpecification {
-  const siteSpecification: SiteSpecification = {
-    repoName: '',
-    pages: [],
-    collections: {},
-    resourceRoom: {
-      name: undefined,
-      categories: [],
-    },
-  }
-
+export default function ({ responses }: { responses: FormField[] }): string {
   const repoNameResponse = responses.find(
     ({ question }) => question === 'Repository Name'
   )
   if (repoNameResponse && repoNameResponse.answer) {
-    siteSpecification.repoName = repoNameResponse.answer
-  }
-  const singlePagesResponse = responses.find(
-    ({ question }) => question === 'Single Pages (Page Name)'
-  )
-  if (singlePagesResponse && singlePagesResponse.answerArray) {
-    siteSpecification.pages = siteSpecification.pages
-      .concat(...singlePagesResponse.answerArray)
-      .filter((s) => s !== '')
-  }
-  const collectionsResponse = responses.find(
-    ({ question }) =>
-      question === 'Page Collections (Collection, Page, Sub-Page)'
-  )
-  if (collectionsResponse && collectionsResponse.answerArray) {
-    const answerArray = ((collectionsResponse.answerArray as unknown) as string[][]).filter(
-      (s) => s[0] !== '' && s[1] !== ''
-    )
-    for (const [name, page, subPage] of answerArray) {
-      if (!siteSpecification.collections[name]) {
-        siteSpecification.collections[name] = {}
-      }
-      if (!siteSpecification.collections[name][page]) {
-        siteSpecification.collections[name][page] = []
-      }
-      if (subPage !== '') {
-        siteSpecification.collections[name][page].push(subPage)
-      }
-    }
-  }
-  const resourceRoomNameResponse = responses.find(
-    ({ question }) => question === 'Resource Room Name'
-  )
-  const resourceRoomCategoriesResponse = responses.find(
-    ({ question }) => question === 'Resource Categories (Name)'
-  )
-
-  if (
-    resourceRoomNameResponse &&
-    resourceRoomNameResponse.answer &&
-    resourceRoomCategoriesResponse &&
-    resourceRoomCategoriesResponse.answerArray
-  ) {
-    siteSpecification.resourceRoom.name = resourceRoomNameResponse.answer
-    siteSpecification.resourceRoom.categories = siteSpecification.resourceRoom.categories.concat(
-      ...resourceRoomCategoriesResponse.answerArray
-    )
+    return repoNameResponse.answer
   }
 
-  return siteSpecification
+  return ''
 }


### PR DESCRIPTION
Changed form and site creation backend to only input and extract repo name.
Creates the following base folders and pages instead:

Pages
- example-page

Collection
- example-collection
   - example-page

Resources
- resources
   - example-category 
