### PR TITLE
fix(config): cloudflare env vars optional

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -111,14 +111,14 @@ const config = convict({
   cloudflareToken: {
     doc: 'API token for our CloudFlare account',
     env: 'CLOUDFLARE_TOKEN',
-    format: 'required-string',
+    format: '*',
     sensitive: true,
     default: '',
   },
   cloudflareZoneId: {
     doc: 'Zone ID for our CloudFlare account',
     env: 'CLOUDFLARE_ZONE_ID',
-    format: 'required-string',
+    format: '*',
     sensitive: true,
     default: '',
   },


### PR DESCRIPTION
Since Cloudflare is only used in `/approve`, ensure that env vars are optional