### PR TITLE
fix: removed unnecessary (and failing) cors proxy from git push calls

### DIFF
--- a/src/services/create-site/github-publisher.ts
+++ b/src/services/create-site/github-publisher.ts
@@ -57,7 +57,6 @@ export default ({
     dir,
     remote,
     remoteRef: 'staging',
-    corsProxy: 'https://cors.isomorphic-git.org',
     onAuth: () => ({ username: 'user', password: githubAccessToken }),
   })
   await git.push({
@@ -66,7 +65,6 @@ export default ({
     dir,
     remote,
     remoteRef: 'master',
-    corsProxy: 'https://cors.isomorphic-git.org',
     onAuth: () => ({ username: 'user', password: githubAccessToken }),
   })
 


### PR DESCRIPTION
This backend uses the isomorphic-git package to create repositories and push them to GitHub. The [push](https://isomorphic-git.org/docs/en/push#docsNav) method has an optional `corsProxy` argument that allows the package to work in a browser, but is unnecessary in a backend such as this. For some reason, we set this argument to `https://cors.isomorphic-git.org/`, a proxy set up by the isomorphic-git project that is only guaranteed to work for requests sent from `https://isomorphic-git.github.io/`, though it [sometimes works](https://isomorphic-git.org/blog/2018/07/08/cors-proxy-origin-limited) from other origins. The configuration of this proxy must have changed on the evening of 11-July-2022, because all of our requests began to fail at that time. The fix is simple: stop using the proxy and everything works.